### PR TITLE
Update template with cleanup and small additions

### DIFF
--- a/components/alert.js
+++ b/components/alert.js
@@ -13,7 +13,7 @@ export default function Alert({ preview }) {
     >
       <Container>
         <div className="py-2 text-center text-sm">
-          {preview ? (
+          {preview && (
             <>
               This page is a preview.{' '}
               <a
@@ -23,17 +23,6 @@ export default function Alert({ preview }) {
                 Click here
               </a>{' '}
               to exit preview mode.
-            </>
-          ) : (
-            <>
-              The source code for this blog is{' '}
-              <a
-                href={`https://github.com/vercel/next.js/tree/canary/examples/${EXAMPLE_PATH}`}
-                className="underline transition-colors duration-200 hover:text-success"
-              >
-                available on GitHub
-              </a>
-              .
             </>
           )}
         </div>

--- a/components/footer.js
+++ b/components/footer.js
@@ -17,7 +17,7 @@ export default function Footer() {
               Read Documentation
             </a>
             <a
-              href={`https://github.com/vercel/next.js/tree/canary/examples/${EXAMPLE_PATH}`}
+              href={`https://${process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER}.com/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER}/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG}`}
               className="mx-3 font-bold hover:underline"
             >
               View on GitHub

--- a/components/intro.js
+++ b/components/intro.js
@@ -1,10 +1,12 @@
 import { CMS_NAME, CMS_URL } from '../lib/constants'
 
-export default function Intro() {
+export default function Intro(props) {
+  const { title } = props
+
   return (
     <section className="mt-16 mb-16 flex flex-col items-center md:mb-12 md:flex-row md:justify-between">
       <h1 className="text-6xl font-bold leading-tight tracking-tighter md:pr-8 md:text-8xl">
-        Blog.
+        {title.title}
       </h1>
       <h4 className="mt-5 text-center text-lg md:pl-8 md:text-left">
         A statically generated blog example using{' '}

--- a/components/intro.js
+++ b/components/intro.js
@@ -1,12 +1,10 @@
 import { CMS_NAME, CMS_URL } from '../lib/constants'
 
-export default function Intro(props) {
-  const { title } = props
-
+export default function Intro({ title }) {
   return (
     <section className="mt-16 mb-16 flex flex-col items-center md:mb-12 md:flex-row md:justify-between">
       <h1 className="text-6xl font-bold leading-tight tracking-tighter md:pr-8 md:text-8xl">
-        {title.title}
+        {title}
       </h1>
       <h4 className="mt-5 text-center text-lg md:pl-8 md:text-left">
         A statically generated blog example using{' '}

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -9,6 +9,8 @@ const postFields = `
   "author": author->{name, picture},
 `
 
+export const titleQuery = `*[_type == "settings"][1]{title}`
+
 export const indexQuery = `
 *[_type == "post"] | order(date desc, _updatedAt desc) {
   ${postFields}

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -9,7 +9,7 @@ const postFields = `
   "author": author->{name, picture},
 `
 
-export const titleQuery = `*[_type == "settings"][1]{title}`
+export const settingsQuery = `*[_type == "settings"][1]{title}`
 
 export const indexQuery = `
 *[_type == "post"] | order(date desc, _updatedAt desc) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,11 +6,11 @@ import Intro from '../components/intro'
 import Layout from '../components/layout'
 import MoreStories from '../components/more-stories'
 import { CMS_NAME } from '../lib/constants'
-import { indexQuery } from '../lib/queries'
+import { indexQuery, titleQuery } from '../lib/queries'
 import { usePreviewSubscription } from '../lib/sanity'
 import { getClient, overlayDrafts } from '../lib/sanity.server'
 
-export default function Index({ allPosts: initialAllPosts, preview }) {
+export default function Index({ allPosts: initialAllPosts, preview, title }) {
   const { data: allPosts } = usePreviewSubscription(indexQuery, {
     initialData: initialAllPosts,
     enabled: preview,
@@ -20,10 +20,10 @@ export default function Index({ allPosts: initialAllPosts, preview }) {
     <>
       <Layout preview={preview}>
         <Head>
-          <title>Next.js Blog Example with {CMS_NAME}</title>
+          <title>{title.title}</title>
         </Head>
         <Container>
-          <Intro />
+          <Intro title={title} />
           {heroPost && (
             <HeroPost
               title={heroPost.title}
@@ -43,8 +43,10 @@ export default function Index({ allPosts: initialAllPosts, preview }) {
 
 export async function getStaticProps({ preview = false }) {
   const allPosts = overlayDrafts(await getClient(preview).fetch(indexQuery))
+  const title = await getClient(preview).fetch(titleQuery)
+
   return {
-    props: { allPosts, preview },
+    props: { allPosts, preview, title },
     // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
     revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,22 +5,27 @@ import HeroPost from '../components/hero-post'
 import Intro from '../components/intro'
 import Layout from '../components/layout'
 import MoreStories from '../components/more-stories'
-import { CMS_NAME } from '../lib/constants'
-import { indexQuery, titleQuery } from '../lib/queries'
+import { indexQuery, settingsQuery } from '../lib/queries'
 import { usePreviewSubscription } from '../lib/sanity'
 import { getClient, overlayDrafts } from '../lib/sanity.server'
 
-export default function Index({ allPosts: initialAllPosts, preview, title }) {
+export default function Index({
+  allPosts: initialAllPosts,
+  preview,
+  blogSettings,
+}) {
   const { data: allPosts } = usePreviewSubscription(indexQuery, {
     initialData: initialAllPosts,
     enabled: preview,
   })
   const [heroPost, ...morePosts] = allPosts || []
+  const { title } = blogSettings || ''
+
   return (
     <>
       <Layout preview={preview}>
         <Head>
-          <title>{title.title}</title>
+          <title>{title}</title>
         </Head>
         <Container>
           <Intro title={title} />
@@ -43,10 +48,10 @@ export default function Index({ allPosts: initialAllPosts, preview, title }) {
 
 export async function getStaticProps({ preview = false }) {
   const allPosts = overlayDrafts(await getClient(preview).fetch(indexQuery))
-  const title = await getClient(preview).fetch(titleQuery)
+  const blogSettings = await getClient(preview).fetch(settingsQuery)
 
   return {
-    props: { allPosts, preview, title },
+    props: { allPosts, preview, blogSettings },
     // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
     revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,
   }

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -4,6 +4,7 @@ import { unsplashImageAsset } from 'sanity-plugin-asset-source-unsplash'
 
 import authorType from './schemas/author'
 import postType from './schemas/post'
+import settingsType from './schemas/settings'
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
@@ -15,8 +16,35 @@ export default createConfig({
   basePath,
   name: 'blog',
   title: 'Blog',
-  plugins: [deskTool(), unsplashImageAsset()],
-  schema: { types: [postType, authorType] },
+  plugins: [
+    deskTool({
+      structure: (S) => {
+        // The `Settings` root list item
+        const settingsListItem = // A singleton not using `documentListItem`, eg no built-in preview
+          S.listItem()
+            .title('Settings')
+            .child(
+              S.document()
+                .schemaType('settings')
+                .documentId('settings')
+                .title('Settings')
+            )
+
+        // The default root list items (except custom ones)
+        const defaultListItems = S.documentTypeListItems().filter(
+          (listItem) => listItem.getId() !== 'settings'
+        )
+
+        return S.list()
+          .title('Content')
+          .items([settingsListItem, S.divider(), ...defaultListItems])
+      },
+    }),
+    unsplashImageAsset(),
+  ],
+  schema: {
+    types: [settingsType, postType, authorType],
+  },
   document: {
     productionUrl: async (prev, { document }) => {
       const secret = process.env.NEXT_PUBLIC_PREVIEW_SECRET

--- a/schemas/settings.ts
+++ b/schemas/settings.ts
@@ -1,0 +1,17 @@
+import { CogIcon } from '@sanity/icons'
+import { defineType } from 'sanity'
+
+export default defineType({
+  name: 'settings',
+  title: 'Settings',
+  type: 'document',
+  icon: CogIcon,
+  fields: [
+    {
+      name: 'title',
+      description: 'This field is the title of your application.',
+      title: 'Title',
+      type: 'string',
+    },
+  ],
+})


### PR DESCRIPTION
- Removed the header in the blog (“The source code for this blog is available on GitHub”)
- Added support for the blog settings singleton & the blog now can have a different name
- Changed footer link to use the env variables to match whatever repo the current user is on
