### PR TITLE
fix: use react 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,17 +7,18 @@
       "dependencies": {
         "@portabletext/react": "^1.0.6",
         "@sanity/image-url": "^1.0.1",
-        "@sanity/vision": "3.0.0-dev-preview.20",
+        "@sanity/vision": "3.0.0-purple-unicorn.6",
         "@sanity/webhook": "^2.0.0",
         "classnames": "^2.3.2",
         "date-fns": "^2.29.3",
-        "next": "latest",
+        "next": "^12.3.1",
         "next-sanity": "^1.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "react-is": "^17.0.2",
-        "sanity": "3.0.0-dev-preview.20",
-        "sanity-plugin-asset-source-unsplash": "3.0.0-v3-studio.5"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-is": "^18.2.0",
+        "sanity": "3.0.0-purple-unicorn.6",
+        "sanity-plugin-asset-source-unsplash": "3.0.0-v3-studio.7",
+        "styled-components": "^5.3.6"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.12",
@@ -39,6 +40,18 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -122,19 +135,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
@@ -753,12 +753,13 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -827,6 +828,64 @@
       "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@motionone/animation": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.14.0.tgz",
+      "integrity": "sha512-h+1sdyBP8vbxEBW5gPFDnj+m2DCqdlAuf2g6Iafb1lcMnqjsRXWlPw1AXgvUMXmreyhqmPbJqoNfIKdytampRQ==",
+      "dependencies": {
+        "@motionone/easing": "^10.14.0",
+        "@motionone/types": "^10.14.0",
+        "@motionone/utils": "^10.14.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/dom": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.13.1.tgz",
+      "integrity": "sha512-zjfX+AGMIt/fIqd/SL1Lj93S6AiJsEA3oc5M9VkUr+Gz+juRmYN1vfvZd6MvEkSqEjwPQgcjN7rGZHrDB9APfQ==",
+      "dependencies": {
+        "@motionone/animation": "^10.13.1",
+        "@motionone/generators": "^10.13.1",
+        "@motionone/types": "^10.13.0",
+        "@motionone/utils": "^10.13.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/easing": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.14.0.tgz",
+      "integrity": "sha512-2vUBdH9uWTlRbuErhcsMmt1jvMTTqvGmn9fHq8FleFDXBlHFs5jZzHJT9iw+4kR1h6a4SZQuCf72b9ji92qNYA==",
+      "dependencies": {
+        "@motionone/utils": "^10.14.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/generators": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.14.0.tgz",
+      "integrity": "sha512-6kRHezoFfIjFN7pPpaxmkdZXD36tQNcyJe3nwVqwJ+ZfC0e3rFmszR8kp9DEVFs9QL/akWjuGPSLBI1tvz+Vjg==",
+      "dependencies": {
+        "@motionone/types": "^10.14.0",
+        "@motionone/utils": "^10.14.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/types": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.14.0.tgz",
+      "integrity": "sha512-3bNWyYBHtVd27KncnJLhksMFQ5o2MSdk1cA/IZqsHtA9DnRM1SYgN01CTcJ8Iw8pCXF5Ocp34tyAjY7WRpOJJQ=="
+    },
+    "node_modules/@motionone/utils": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.14.0.tgz",
+      "integrity": "sha512-sLWBLPzRqkxmOTRzSaD3LFQXCPHvDzyHJ1a3VP9PRzBxyVd2pv51/gMOsdAcxQ9n+MIeGJnxzXBYplUHKj4jkw==",
+      "dependencies": {
+        "@motionone/types": "^10.14.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@next/env": {
@@ -1107,32 +1166,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/@reach/auto-id": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
-      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
-      "dependencies": {
-        "@reach/utils": "0.17.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/utils": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
-      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
     "node_modules/@rexxars/react-json-inspector": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@rexxars/react-json-inspector/-/react-json-inspector-8.0.1.tgz",
@@ -1144,6 +1177,20 @@
       },
       "peerDependencies": {
         "react": "^15 || ^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@rexxars/react-sortable-hoc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rexxars/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
+      "integrity": "sha512-wAbfK73pvmUG+wZ+oRhx86tjENzWCcZ3BOlcy0OZpV9tx+py2EmRI7fRtFAe6OjF7fTXqQZ259yPxkDguun0xg==",
+      "dependencies": {
+        "@babel/runtime": "^7.2.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.7"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -1170,21 +1217,23 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-io2t4E1Y8x+9acY4+qpdoCGpTpDBfTSjLJ5VHnpm8aBqU6D0C2fkK2Ct5MzhcJwdMTNx73AIUkVN9i3DSp41oA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-dZKH26hCjrNu/BuHapq3hwlymcQgOITWdlDhLQj/NBCE1xd8YM1UP/m0yaPlxDzve/MMVMw/12Ib27cebMrj+w==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-YPku3qSTqkAn1IiA+SuZ/6yUMMGM+86yaHg7gMorTHAkdLFvBXahwePDRh3jlySLAehQICPdPNQUIcmByLoq+w==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-saoSIf3cBi7XGQ05VPhm93ykq2nbO0ECNOSexvfk41zrMb5TTyi2ZAkewYpO9kFHRNUL+j75ppYsverp0b5NsQ==",
       "dependencies": {
+        "@babel/traverse": "^7.19.0",
         "esbuild": "^0.14.43",
         "esbuild-register": "^3.3.2",
+        "get-it": "^5.2.1",
         "pkg-dir": "^5.0.0"
       },
       "bin": {
@@ -1193,6 +1242,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@sanity/cli/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@sanity/cli/node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sanity/cli/node_modules/get-it": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.2.1.tgz",
+      "integrity": "sha512-KDR5lTKmxKd/XyP3egZ8ieIdKLxKrQPKUFxk86MSoytGjxX4STigaFuwtFGmGx/lBPc1YSpi9wyuQJ5uP8WcRA==",
+      "dependencies": {
+        "@sanity/timed-out": "^4.0.2",
+        "create-error-class": "^3.0.2",
+        "debug": "^2.6.8",
+        "decompress-response": "^3.3.0",
+        "follow-redirects": "^1.2.4",
+        "form-urlencoded": "^2.0.7",
+        "into-stream": "^3.1.0",
+        "is-plain-object": "^2.0.4",
+        "is-retry-allowed": "^1.1.0",
+        "is-stream": "^1.1.0",
+        "nano-pubsub": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "parse-headers": "^2.0.1",
+        "progress-stream": "^2.0.0",
+        "same-origin": "^0.1.1",
+        "simple-concat": "^1.0.0",
+        "tunnel-agent": "^0.6.0",
+        "url-parse": "^1.1.9"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@sanity/cli/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sanity/cli/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/@sanity/client": {
       "version": "3.4.1",
@@ -1210,14 +1319,14 @@
       }
     },
     "node_modules/@sanity/color": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.16.tgz",
-      "integrity": "sha512-R5Wh4qt+Jv20nvwSwE5xA+eS3kF2diPA6noAPQZSUsSG9UIUGGgxJyU0hWUa9O06RTCNqgBQI1YJiZTeJ6S7SA=="
+      "version": "2.1.17-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.17-next.30.tgz",
+      "integrity": "sha512-aodt2NtC1EPTdZLRRS2zcSYyMUfhqit2GpHh07ptWDRZy0ZLxZoBnRNJPsHK5DvCXeguNP1kHSRgn5h/B/g+AQ=="
     },
     "node_modules/@sanity/diff": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-obRgNyRqmWRscMhVScRUjrnyDrhkgZ58rhCb63rRkATtKKBMIxFB59cpRzp+u/z3sIYRQVWUGL/LDdRwasFrzA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-uMKzvsXrmCUD/k1BomhseLyCu6Ky+UG/7RzOO34nnvxwtChpxNaoG4CPG3rXuY8BTYrddkNqXyBL/4h0rveFuw==",
       "dependencies": {
         "diff-match-patch": "^1.0.4"
       },
@@ -1235,9 +1344,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-Ope4DB7TMp4LY78VohlKgweuj+IGfSzf/0NRBudpihUuEbUdBhxdKnFC9opa/JiP3O5Zpm6wz3cDFoROTF1UoQ==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-kq3HavpDUbt2tp/dndSIH+kkv5nZasZ59bsRvjkKDG8I2uHcWyvlGDii3/a3YL+pFhJIUxZM7mOOvThQps1k8g==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -1374,11 +1483,11 @@
       }
     },
     "node_modules/@sanity/icons": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.6.tgz",
-      "integrity": "sha512-/GeFmwHMQVTCBvo4qAQgZJHKB1UzU8u42gnjs6696PWh626G4xbElb3/YJ9sM1PwTc0OaYrvIDes8qUTvrlhrA==",
+      "version": "1.3.7-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.7-next.30.tgz",
+      "integrity": "sha512-k+R4zHb1XzhHgXZDP/u7bUP6PRvHFOp0YrBme4tyJ+qbH2aLhQo5OVmvp9R3Zx74GtC7y3IIq19rIiiZDM0U+Q==",
       "peerDependencies": {
-        "react": "^16.9 || ^17 || ^18"
+        "react": "^18"
       }
     },
     "node_modules/@sanity/image-url": {
@@ -1390,13 +1499,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-hhj73xvTTNxomnU30XzBv0j0z3uNj4kt3C9awVT8hCNb6gjveaDL7fMGC8E3pzdfpEipH/k3KY81/UGjoE7dfA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-GdfQisEXUJaKSDxJRiYPjTolo8VB902uuYBOxVz5jGrgy5dY30vehh+t0Ri9HO/m32t/6I0z2nfYhL+y1vO5XA==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.0.0-dev-preview.20",
+        "@sanity/mutator": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -1537,19 +1646,27 @@
         "react-dom": "^16.9 || ^17 || ^18"
       }
     },
-    "node_modules/@sanity/logos": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-1.1.15.tgz",
-      "integrity": "sha512-bO5kQOqOQcM2t1AAl+TREU7gRFEBCH9KmvZ0bgyCRU5VAWPnDniQyMDkgeyzb+wnJwg79+SYmLDdt8OnZrPlTQ==",
+    "node_modules/@sanity/incompatible-plugin/node_modules/@sanity/icons": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.6.tgz",
+      "integrity": "sha512-/GeFmwHMQVTCBvo4qAQgZJHKB1UzU8u42gnjs6696PWh626G4xbElb3/YJ9sM1PwTc0OaYrvIDes8qUTvrlhrA==",
       "peerDependencies": {
-        "@sanity/color": "^2.0",
         "react": "^16.9 || ^17 || ^18"
       }
     },
+    "node_modules/@sanity/logos": {
+      "version": "1.1.18-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-1.1.18-next.30.tgz",
+      "integrity": "sha512-92fDyBx4V68vMVCJ133rfT11DlPp6rmOCQR8P3ZH7zQ+d0kPlpRqfc3ldHlwoSf4M1TU70cUPVq7sTa0izwZmg==",
+      "peerDependencies": {
+        "@sanity/color": "^2.0",
+        "react": "^18"
+      }
+    },
     "node_modules/@sanity/mutator": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-ABrqXyHe5xZC903U1xKsGLDcHQxMPa9cI7b03iW2l8WuaTsVg/QdT5TzMwXdnRkAgvzJsytYY6JQ96Nh4f52tw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-uXivg4+RBljOMjo+YNBVb0UIwEfkLqlZpNvp5LWskAsqFKdTJ7+RkhUZ6DdHyM4m96zSTDrOtcKAtkrefEph9w==",
       "dependencies": {
         "@sanity/uuid": "^3.0.1",
         "@types/diff-match-patch": "^1.0.32",
@@ -1567,15 +1684,16 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-SyWULiznib4u3V0AsgE9AtNtjYnowynrsXkuglLfkMU1X5scz7XFfU45Mt1zvgb91YN8jChHEzI5ZdIoF0xljg==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-pWW1WB5jR/6OFDwk5/uoebIA44lqyOUEVBnW2YzSdTCvvlHrbTOf8spvhH2tBrObQBc7IP0Y95M8XSU3OPHM/w==",
       "dependencies": {
-        "@sanity/block-tools": "3.0.0-dev-preview.20",
-        "@sanity/schema": "3.0.0-dev-preview.20",
+        "@sanity/block-tools": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/schema": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.0.0-dev-preview.20",
-        "@sanity/util": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/ui": "0.38.3-next.30",
+        "@sanity/util": "3.0.0-purple-unicorn.6+ef1e764093",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -1585,18 +1703,28 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
+        "react": "^16.9 || ^17 || ^18",
         "rxjs": ">=6.5.3",
-        "styled-components": "^5.2.0"
+        "styled-components": "^5.2"
       }
     },
     "node_modules/@sanity/portable-text-editor/node_modules/@sanity/types": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^17.0.42"
+        "@types/react": "^18.0.21"
+      }
+    },
+    "node_modules/@sanity/portable-text-editor/node_modules/@types/react": {
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@sanity/portable-text-editor/node_modules/debug": {
@@ -1608,12 +1736,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-GD4MKMgKHL8JL4DKFbyVAK4SQkXNvY8kyMr18UBOxL9mA6/vhXeS7H0V5rGNge7wSgf1SFcYsLExhnaNJWzAzw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-N4k14WEFImx7XPNAwFLCwUAudSw3m52C9p5MLO7KOOqnnXHgYCbYy2LI3TlLM1ftRa23SRgaL7GiKls2ngpOYQ==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -1622,18 +1750,28 @@
       }
     },
     "node_modules/@sanity/schema/node_modules/@sanity/types": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^17.0.42"
+        "@types/react": "^18.0.21"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/@types/react": {
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@sanity/server": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-IAuGkYsCYFuYTuFcDWx+I3mGoEBbPBe+nU1uY7QOCJyHvpP5a4Fy8LtyT/Xp60/uYFUJEhKjo8yKG+/8WnV5Xg==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-J1R2raj+Aeyt1PAuoOhmxDPB8RWO7mlhvHnI4GVCByPagNF2BXzu5WVY9ZR2yjVVVB8pIwZFqTefasHMaMENmw==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
         "@vitejs/plugin-react": "^2.0.0",
@@ -1651,6 +1789,10 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18",
+        "react-dom": "^18"
       }
     },
     "node_modules/@sanity/server/node_modules/debug": {
@@ -1716,34 +1858,38 @@
         "rxjs": "^6.5.3"
       }
     },
+    "node_modules/@sanity/types/node_modules/@sanity/color": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.16.tgz",
+      "integrity": "sha512-R5Wh4qt+Jv20nvwSwE5xA+eS3kF2diPA6noAPQZSUsSG9UIUGGgxJyU0hWUa9O06RTCNqgBQI1YJiZTeJ6S7SA=="
+    },
     "node_modules/@sanity/ui": {
-      "version": "0.38.2",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.38.2.tgz",
-      "integrity": "sha512-jP0NoEmSIws97tkLifRHuzTKvEztXakcAGuJ6jJ45IYUjgQXZp3bpDobfD9TZY4eeR0WafUB3UntkfSHqRVNOQ==",
+      "version": "0.38.3-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.38.3-next.30.tgz",
+      "integrity": "sha512-hilbAt6j6yE0t+fkEu9eVwiZTr6ZPtQI59TCa4YnhtlmHLnwlDHbwUhr5+Xy5Qo3KNRXsuPwbFfsHxAbVlKLTQ==",
       "dependencies": {
-        "@juggle/resize-observer": "^3.4.0",
         "@popperjs/core": "^2.11.6",
-        "@reach/auto-id": "^0.17.0",
-        "@sanity/color": "^2.1.16",
-        "@sanity/icons": "^1.3.6",
-        "framer-motion": "6.3.0",
+        "@sanity/color": "2.1.17-next.30+8cd982e0",
+        "@sanity/icons": "1.3.7-next.30+8cd982e0",
+        "framer-motion": "^7.5.2",
         "popper-max-size-modifier": "^0.2.0",
-        "react-is": "^17.0.2",
+        "react-is": "^18.2.0",
         "react-popper": "^2.3.0",
         "react-refractor": "^2.1.7"
       },
       "peerDependencies": {
-        "react": "^16.9 || ^17 || ^18",
-        "react-dom": "^16.9 || ^17 || ^18",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-is": "^18",
         "styled-components": "^5.2"
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-NLwe3oDMkS42+LJksu7qTOQP6R86oYcyy6Mxn7FF34yMy5y5YDc4c9kFkf3p/F1boOoiyA5vr5XWaudGpqZ/Kg==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-xr6+Sv1JTtGjnBGDTHShi3TS8dnm52NHB/AoNbCzSxNwGw4Y4nL8c/BF0+RWin6QVzFG239sG3RpcuaZnmJWQQ==",
       "dependencies": {
-        "@sanity/types": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -1752,12 +1898,22 @@
       }
     },
     "node_modules/@sanity/util/node_modules/@sanity/types": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^17.0.42"
+        "@types/react": "^18.0.21"
+      }
+    },
+    "node_modules/@sanity/util/node_modules/@types/react": {
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@sanity/uuid": {
@@ -1770,28 +1926,42 @@
       }
     },
     "node_modules/@sanity/validation": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-i3BmytuikNR6e3tzPRq/AGYCgHSJAVsCQaCJmyU9vgBsYVBi5UrS0O2HPZZJEEcJK0E951F+YWSIIS/FCuFZpw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-Ypk/sm7IM+Cr3f4mMelHwUF/k2i2zkMLBPGdv7gaHVFYxfMD1zuMGBq8u+vCn5jRO6CErHsy9DFXSmlexbBaRg==",
       "dependencies": {
-        "@sanity/types": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
         "date-fns": "^2.26.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "rxjs": "^6.5.3"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^3.4.1"
       }
     },
     "node_modules/@sanity/validation/node_modules/@sanity/types": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^17.0.42"
+        "@types/react": "^18.0.21"
+      }
+    },
+    "node_modules/@sanity/validation/node_modules/@types/react": {
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-FTW7TJHbLTFYvASgGixbcnT2yec0cmKXOYHXEOJrICTTKRe3t9sF7gtvD8HUPfcQKJKl3JpxzNBkKiRUpgE5Yw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-xnsX9LYS3evII5fOkpraew/7wAixJlxAwUoH84fHNHXq59BUuCC2plxI+Lb//vmosv8ZkVSrpRDcLeKZk+3RPA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1802,9 +1972,9 @@
         "@juggle/resize-observer": "^3.3.1",
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
-        "@sanity/color": "^2.1.16",
-        "@sanity/icons": "^1.3.6",
-        "@sanity/ui": "^0.38.2",
+        "@sanity/color": "2.1.17-next.30",
+        "@sanity/icons": "1.3.7-next.30",
+        "@sanity/ui": "0.38.3-next.30",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -1813,9 +1983,10 @@
         "react-split-pane": "^0.1.84"
       },
       "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18",
-        "styled-components": "^5.2.0"
+        "@sanity/client": "^3.4.1",
+        "react": "^18",
+        "rxjs": "^6.5.3",
+        "styled-components": "^5.2"
       }
     },
     "node_modules/@sanity/webhook": {
@@ -1954,11 +2125,6 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-    },
-    "node_modules/@types/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.40.0",
@@ -4663,30 +4829,31 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.0.tgz",
-      "integrity": "sha512-Nm6l2cemuFeSC1fmq9R32sCQs1eplOuZ3r14/PxRDewpE3NUr+ul5ulGRRzk8K0Aa5p76Tedi3sfCUaTPa5fRg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.5.3.tgz",
+      "integrity": "sha512-VvANga9Z7bYtKMAsM/je81FwJDHfThOYywN04xVQ4OGdMVY09Bowx/q7nZd6XtytLuv6byc6GT1mYwag+SQ/nw==",
       "dependencies": {
-        "framesync": "6.0.1",
+        "@motionone/dom": "10.13.1",
+        "framesync": "6.1.2",
         "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "popmotion": "11.0.5",
+        "style-value-types": "5.1.2",
+        "tslib": "2.4.0"
       },
       "optionalDependencies": {
         "@emotion/is-prop-valid": "^0.8.2"
       },
       "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "node_modules/from2": {
@@ -5822,9 +5989,9 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-reduce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-reduce/-/json-reduce-2.0.0.tgz",
-      "integrity": "sha512-qHVKlo1O0gbDw9rBUGVOKocopfdDTwVjeAyuO8Oatg58sTD8rqM4Hp6MyYZIsta36QXHjL4sagT8/Nn52cHs8Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-reduce/-/json-reduce-3.0.0.tgz",
+      "integrity": "sha512-zvnhEvwhqTOxBIcXnxvHvhqtubdwFRp+FascmCaL56BT9jdttRU8IFc+Ilh2HPJ0AtioF8mFPxmReuJKLW0Iyw=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6901,14 +7068,14 @@
       }
     },
     "node_modules/popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.5.tgz",
+      "integrity": "sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA==",
       "dependencies": {
-        "framesync": "6.0.1",
+        "framesync": "6.1.2",
         "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "style-value-types": "5.1.2",
+        "tslib": "2.4.0"
       }
     },
     "node_modules/popper-max-size-modifier": {
@@ -7266,12 +7433,11 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -7301,16 +7467,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-fast-compare": {
@@ -7360,9 +7525,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -7436,21 +7601,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "rxjs": "^6.5 || ^7"
-      }
-    },
-    "node_modules/react-sortable-hoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
-      "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
-      "dependencies": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.7",
-        "react": "^16.3.0 || ^17.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/react-split-pane": {
@@ -7844,41 +7994,41 @@
       "integrity": "sha512-effkSW9cap879l6CVNdwL5iubVz8tkspqgfiqwgBgFQspV7152WHaLzr5590yR8oFgt7E1d4lO09uUhtAgUPoA=="
     },
     "node_modules/sanity": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-wcVer7UbXfE9C0nJqppX22CMcNdoyZeoUDQ29JarHz6y2cvpiOCe+JNPchtGpQRkAgbCgkeNce/d7QgxGActPA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-j65GiTgRgwsYjPrejIHlcMzEPgkPqEfTJS7LfPaHj3aW6I1yfw1WWONL3tbAtoUUPzjkxtzFlnu5weWAtijWhA==",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
         "@portabletext/react": "^1.0.6",
         "@portabletext/types": "^1.0.3",
-        "@reach/auto-id": "^0.13.2",
         "@rexxars/react-json-inspector": "^8.0.1",
+        "@rexxars/react-sortable-hoc": "^2.0.0",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.0",
-        "@sanity/block-tools": "3.0.0-dev-preview.20",
-        "@sanity/cli": "3.0.0-dev-preview.20",
+        "@sanity/block-tools": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/cli": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/client": "^3.4.1",
-        "@sanity/color": "^2.1.16",
-        "@sanity/diff": "3.0.0-dev-preview.20",
+        "@sanity/color": "2.1.17-next.30",
+        "@sanity/diff": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/eventsource": "^3.0.1",
-        "@sanity/export": "3.0.0-dev-preview.20",
+        "@sanity/export": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "^1.3.6",
+        "@sanity/icons": "1.3.7-next.30",
         "@sanity/image-url": "^1.0.1",
-        "@sanity/import": "3.0.0-dev-preview.20",
-        "@sanity/logos": "1.1.15",
-        "@sanity/mutator": "3.0.0-dev-preview.20",
-        "@sanity/portable-text-editor": "3.0.0-dev-preview.20",
-        "@sanity/schema": "3.0.0-dev-preview.20",
-        "@sanity/server": "3.0.0-dev-preview.20",
-        "@sanity/types": "3.0.0-dev-preview.20",
-        "@sanity/ui": "^0.38.2",
-        "@sanity/util": "3.0.0-dev-preview.20",
+        "@sanity/import": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/logos": "1.1.18-next.30",
+        "@sanity/mutator": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/portable-text-editor": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/schema": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/server": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/ui": "0.38.3-next.30",
+        "@sanity/util": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.0.0-dev-preview.20",
+        "@sanity/validation": "3.0.0-purple-unicorn.6+ef1e764093",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
-        "@types/react-is": "^17.0.1",
+        "@types/react-is": "^17.0.3",
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
         "chalk": "^4.1.2",
@@ -7905,7 +8055,7 @@
         "jsdom": "^20.0.0",
         "jsdom-global": "^3.0.2",
         "json-lexer": "^1.2.0",
-        "json-reduce": "^2.0.0",
+        "json-reduce": "^3.0.0",
         "json5": "^1.0.1",
         "lodash": "^4.17.21",
         "log-symbols": "^2.2.0",
@@ -7922,18 +8072,17 @@
         "react-copy-to-clipboard": "^5.0.4",
         "react-fast-compare": "^3.2.0",
         "react-focus-lock": "^2.8.1",
-        "react-is": "^17.0.2",
+        "react-is": "^18.2.0",
         "react-props-stream": "^1.0.0",
         "react-refractor": "^2.1.6",
         "react-rx": "^2.0.4",
-        "react-sortable-hoc": "^2.0.0",
         "read-pkg-up": "^7.0.1",
         "refractor": "^3.6.0",
         "resolve-from": "^5.0.0",
         "rimraf": "^3.0.2",
         "rxjs": "^6.5.3",
         "rxjs-etc": "^10.6.0",
-        "rxjs-exhaustmap-with-trailing": "^1.0.0",
+        "rxjs-exhaustmap-with-trailing": "^1.2.0",
         "sanity-diff-patch": "^1.0.9",
         "scroll-into-view-if-needed": "^2.2.29",
         "semver": "^7.3.5",
@@ -7951,9 +8100,9 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": "^16.9 || ^17 || ^18",
-        "react-dom": "^16.9 || ^17 || ^18",
-        "styled-components": "^5.2.0"
+        "react": "^18",
+        "react-dom": "^18",
+        "styled-components": "^5.2"
       }
     },
     "node_modules/sanity-diff-patch": {
@@ -7968,52 +8117,38 @@
       }
     },
     "node_modules/sanity-plugin-asset-source-unsplash": {
-      "version": "3.0.0-v3-studio.5",
-      "resolved": "https://registry.npmjs.org/sanity-plugin-asset-source-unsplash/-/sanity-plugin-asset-source-unsplash-3.0.0-v3-studio.5.tgz",
-      "integrity": "sha512-cC+xskZQ/CvLTf6tiI8i3OIh9jpbIPZ731i8WlyHCrv6CQHWISFlmajk6RwAL9gqLbhjCbM4DWzzdjNHfrNzEg==",
+      "version": "3.0.0-v3-studio.7",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-asset-source-unsplash/-/sanity-plugin-asset-source-unsplash-3.0.0-v3-studio.7.tgz",
+      "integrity": "sha512-OpDmmy+kXjWs0VJFlce7uQFj0VDGWdvUAbhHsYLlarEw5gC3lfZePmDHx4Ii3PnCG7VDne29FDPAJ8nzjAdAXA==",
       "dependencies": {
-        "@sanity/incompatible-plugin": "^1.0.0",
-        "@sanity/ui": "^0.38.0",
-        "lodash": ">=4.17.4",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "0.38.3-next.30",
+        "lodash": "^4.17.21",
         "react-infinite-scroll-component": "^6.1.0",
-        "react-photo-album": "^1.13.2",
-        "rxjs": ">=6.5.2",
-        "styled-components": "^5.2.0"
+        "react-photo-album": "^1.16.1",
+        "rxjs": "^6.5.2"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "sanity": "dev-preview"
+        "react": "^18",
+        "react-dom": "^18",
+        "sanity": "dev-preview",
+        "styled-components": "^5.2"
       }
     },
-    "node_modules/sanity/node_modules/@reach/auto-id": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.13.2.tgz",
-      "integrity": "sha512-dWeXt6xxjN+NPRoZFXgmNkF89t8MEPsWLYjIIDf3gNXA/Dxaoytc9YBOIfVGpDSpdOwxPpxOu8rH+4Y3Jk2gHA==",
+    "node_modules/sanity/node_modules/@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
       "dependencies": {
-        "@reach/utils": "0.13.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/sanity/node_modules/@reach/utils": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
-      "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
-      "dependencies": {
-        "@types/warning": "^3.0.0",
-        "tslib": "^2.1.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/sanity/node_modules/@sanity/eventsource": {
@@ -8026,12 +8161,22 @@
       }
     },
     "node_modules/sanity/node_modules/@sanity/types": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^17.0.42"
+        "@types/react": "^18.0.21"
+      }
+    },
+    "node_modules/sanity/node_modules/@types/react": {
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/sanity/node_modules/debug": {
@@ -8059,6 +8204,34 @@
       "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/sanity/node_modules/framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "dependencies": {
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/sanity/node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/sanity/node_modules/get-it": {
@@ -8125,12 +8298,32 @@
       "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-2.0.1.tgz",
       "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA=="
     },
+    "node_modules/sanity/node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/sanity/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sanity/node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/saxes": {
@@ -8145,12 +8338,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/scroll-into-view-if-needed": {
@@ -8552,12 +8744,12 @@
       "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
     },
     "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.1.2.tgz",
+      "integrity": "sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q==",
       "dependencies": {
         "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "node_modules/styled-components": {
@@ -9801,6 +9993,17 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+          "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+          "requires": {
+            "@jridgewell/set-array": "^1.0.0",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -9858,18 +10061,6 @@
         "@babel/types": "^7.19.4",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
-      },
-      "dependencies": {
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -10334,12 +10525,13 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "requires": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@jridgewell/resolve-uri": {
@@ -10399,6 +10591,64 @@
       "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
       "requires": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "@motionone/animation": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.14.0.tgz",
+      "integrity": "sha512-h+1sdyBP8vbxEBW5gPFDnj+m2DCqdlAuf2g6Iafb1lcMnqjsRXWlPw1AXgvUMXmreyhqmPbJqoNfIKdytampRQ==",
+      "requires": {
+        "@motionone/easing": "^10.14.0",
+        "@motionone/types": "^10.14.0",
+        "@motionone/utils": "^10.14.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/dom": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.13.1.tgz",
+      "integrity": "sha512-zjfX+AGMIt/fIqd/SL1Lj93S6AiJsEA3oc5M9VkUr+Gz+juRmYN1vfvZd6MvEkSqEjwPQgcjN7rGZHrDB9APfQ==",
+      "requires": {
+        "@motionone/animation": "^10.13.1",
+        "@motionone/generators": "^10.13.1",
+        "@motionone/types": "^10.13.0",
+        "@motionone/utils": "^10.13.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/easing": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.14.0.tgz",
+      "integrity": "sha512-2vUBdH9uWTlRbuErhcsMmt1jvMTTqvGmn9fHq8FleFDXBlHFs5jZzHJT9iw+4kR1h6a4SZQuCf72b9ji92qNYA==",
+      "requires": {
+        "@motionone/utils": "^10.14.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/generators": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.14.0.tgz",
+      "integrity": "sha512-6kRHezoFfIjFN7pPpaxmkdZXD36tQNcyJe3nwVqwJ+ZfC0e3rFmszR8kp9DEVFs9QL/akWjuGPSLBI1tvz+Vjg==",
+      "requires": {
+        "@motionone/types": "^10.14.0",
+        "@motionone/utils": "^10.14.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/types": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.14.0.tgz",
+      "integrity": "sha512-3bNWyYBHtVd27KncnJLhksMFQ5o2MSdk1cA/IZqsHtA9DnRM1SYgN01CTcJ8Iw8pCXF5Ocp34tyAjY7WRpOJJQ=="
+    },
+    "@motionone/utils": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.14.0.tgz",
+      "integrity": "sha512-sLWBLPzRqkxmOTRzSaD3LFQXCPHvDzyHJ1a3VP9PRzBxyVd2pv51/gMOsdAcxQ9n+MIeGJnxzXBYplUHKj4jkw==",
+      "requires": {
+        "@motionone/types": "^10.14.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
       }
     },
     "@next/env": {
@@ -10543,24 +10793,6 @@
       "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-1.0.3.tgz",
       "integrity": "sha512-SDDsdury2SaTI2D5Ea6o+Y39SSZMYHRMWJHxkxYl3yzFP0n/0EknOhoXcoaV+bxGr2dTTqZi2TOEj+uWYuavSw=="
     },
-    "@reach/auto-id": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
-      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
-      "requires": {
-        "@reach/utils": "0.17.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@reach/utils": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
-      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
-      "requires": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      }
-    },
     "@rexxars/react-json-inspector": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@rexxars/react-json-inspector/-/react-json-inspector-8.0.1.tgz",
@@ -10569,6 +10801,16 @@
         "create-react-class": "^15.6.0",
         "debounce": "1.0.0",
         "md5-o-matic": "^0.1.1"
+      }
+    },
+    "@rexxars/react-sortable-hoc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rexxars/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
+      "integrity": "sha512-wAbfK73pvmUG+wZ+oRhx86tjENzWCcZ3BOlcy0OZpV9tx+py2EmRI7fRtFAe6OjF7fTXqQZ259yPxkDguun0xg==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.7"
       }
     },
     "@rushstack/eslint-patch": {
@@ -10592,22 +10834,77 @@
       }
     },
     "@sanity/block-tools": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-io2t4E1Y8x+9acY4+qpdoCGpTpDBfTSjLJ5VHnpm8aBqU6D0C2fkK2Ct5MzhcJwdMTNx73AIUkVN9i3DSp41oA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-dZKH26hCjrNu/BuHapq3hwlymcQgOITWdlDhLQj/NBCE1xd8YM1UP/m0yaPlxDzve/MMVMw/12Ib27cebMrj+w==",
       "requires": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "@sanity/cli": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-YPku3qSTqkAn1IiA+SuZ/6yUMMGM+86yaHg7gMorTHAkdLFvBXahwePDRh3jlySLAehQICPdPNQUIcmByLoq+w==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-saoSIf3cBi7XGQ05VPhm93ykq2nbO0ECNOSexvfk41zrMb5TTyi2ZAkewYpO9kFHRNUL+j75ppYsverp0b5NsQ==",
       "requires": {
+        "@babel/traverse": "^7.19.0",
         "esbuild": "^0.14.43",
         "esbuild-register": "^3.3.2",
+        "get-it": "^5.2.1",
         "pkg-dir": "^5.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "get-it": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.2.1.tgz",
+          "integrity": "sha512-KDR5lTKmxKd/XyP3egZ8ieIdKLxKrQPKUFxk86MSoytGjxX4STigaFuwtFGmGx/lBPc1YSpi9wyuQJ5uP8WcRA==",
+          "requires": {
+            "@sanity/timed-out": "^4.0.2",
+            "create-error-class": "^3.0.2",
+            "debug": "^2.6.8",
+            "decompress-response": "^3.3.0",
+            "follow-redirects": "^1.2.4",
+            "form-urlencoded": "^2.0.7",
+            "into-stream": "^3.1.0",
+            "is-plain-object": "^2.0.4",
+            "is-retry-allowed": "^1.1.0",
+            "is-stream": "^1.1.0",
+            "nano-pubsub": "^1.0.2",
+            "object-assign": "^4.1.1",
+            "parse-headers": "^2.0.1",
+            "progress-stream": "^2.0.0",
+            "same-origin": "^0.1.1",
+            "simple-concat": "^1.0.0",
+            "tunnel-agent": "^0.6.0",
+            "url-parse": "^1.1.9"
+          }
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
       }
     },
     "@sanity/client": {
@@ -10623,14 +10920,14 @@
       }
     },
     "@sanity/color": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.16.tgz",
-      "integrity": "sha512-R5Wh4qt+Jv20nvwSwE5xA+eS3kF2diPA6noAPQZSUsSG9UIUGGgxJyU0hWUa9O06RTCNqgBQI1YJiZTeJ6S7SA=="
+      "version": "2.1.17-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.17-next.30.tgz",
+      "integrity": "sha512-aodt2NtC1EPTdZLRRS2zcSYyMUfhqit2GpHh07ptWDRZy0ZLxZoBnRNJPsHK5DvCXeguNP1kHSRgn5h/B/g+AQ=="
     },
     "@sanity/diff": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-obRgNyRqmWRscMhVScRUjrnyDrhkgZ58rhCb63rRkATtKKBMIxFB59cpRzp+u/z3sIYRQVWUGL/LDdRwasFrzA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-uMKzvsXrmCUD/k1BomhseLyCu6Ky+UG/7RzOO34nnvxwtChpxNaoG4CPG3rXuY8BTYrddkNqXyBL/4h0rveFuw==",
       "requires": {
         "diff-match-patch": "^1.0.4"
       }
@@ -10645,9 +10942,9 @@
       }
     },
     "@sanity/export": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-Ope4DB7TMp4LY78VohlKgweuj+IGfSzf/0NRBudpihUuEbUdBhxdKnFC9opa/JiP3O5Zpm6wz3cDFoROTF1UoQ==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-kq3HavpDUbt2tp/dndSIH+kkv5nZasZ59bsRvjkKDG8I2uHcWyvlGDii3/a3YL+pFhJIUxZM7mOOvThQps1k8g==",
       "requires": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -10769,9 +11066,9 @@
       }
     },
     "@sanity/icons": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.6.tgz",
-      "integrity": "sha512-/GeFmwHMQVTCBvo4qAQgZJHKB1UzU8u42gnjs6696PWh626G4xbElb3/YJ9sM1PwTc0OaYrvIDes8qUTvrlhrA=="
+      "version": "1.3.7-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.7-next.30.tgz",
+      "integrity": "sha512-k+R4zHb1XzhHgXZDP/u7bUP6PRvHFOp0YrBme4tyJ+qbH2aLhQo5OVmvp9R3Zx74GtC7y3IIq19rIiiZDM0U+Q=="
     },
     "@sanity/image-url": {
       "version": "1.0.1",
@@ -10779,13 +11076,13 @@
       "integrity": "sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg=="
     },
     "@sanity/import": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-hhj73xvTTNxomnU30XzBv0j0z3uNj4kt3C9awVT8hCNb6gjveaDL7fMGC8E3pzdfpEipH/k3KY81/UGjoE7dfA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-GdfQisEXUJaKSDxJRiYPjTolo8VB902uuYBOxVz5jGrgy5dY30vehh+t0Ri9HO/m32t/6I0z2nfYhL+y1vO5XA==",
       "requires": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.0.0-dev-preview.20",
+        "@sanity/mutator": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -10906,17 +11203,24 @@
       "requires": {
         "@sanity/icons": "^1.3",
         "react-copy-to-clipboard": "^5.1.0"
+      },
+      "dependencies": {
+        "@sanity/icons": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.6.tgz",
+          "integrity": "sha512-/GeFmwHMQVTCBvo4qAQgZJHKB1UzU8u42gnjs6696PWh626G4xbElb3/YJ9sM1PwTc0OaYrvIDes8qUTvrlhrA=="
+        }
       }
     },
     "@sanity/logos": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-1.1.15.tgz",
-      "integrity": "sha512-bO5kQOqOQcM2t1AAl+TREU7gRFEBCH9KmvZ0bgyCRU5VAWPnDniQyMDkgeyzb+wnJwg79+SYmLDdt8OnZrPlTQ=="
+      "version": "1.1.18-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-1.1.18-next.30.tgz",
+      "integrity": "sha512-92fDyBx4V68vMVCJ133rfT11DlPp6rmOCQR8P3ZH7zQ+d0kPlpRqfc3ldHlwoSf4M1TU70cUPVq7sTa0izwZmg=="
     },
     "@sanity/mutator": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-ABrqXyHe5xZC903U1xKsGLDcHQxMPa9cI7b03iW2l8WuaTsVg/QdT5TzMwXdnRkAgvzJsytYY6JQ96Nh4f52tw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-uXivg4+RBljOMjo+YNBVb0UIwEfkLqlZpNvp5LWskAsqFKdTJ7+RkhUZ6DdHyM4m96zSTDrOtcKAtkrefEph9w==",
       "requires": {
         "@sanity/uuid": "^3.0.1",
         "@types/diff-match-patch": "^1.0.32",
@@ -10936,15 +11240,16 @@
       }
     },
     "@sanity/portable-text-editor": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-SyWULiznib4u3V0AsgE9AtNtjYnowynrsXkuglLfkMU1X5scz7XFfU45Mt1zvgb91YN8jChHEzI5ZdIoF0xljg==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-pWW1WB5jR/6OFDwk5/uoebIA44lqyOUEVBnW2YzSdTCvvlHrbTOf8spvhH2tBrObQBc7IP0Y95M8XSU3OPHM/w==",
       "requires": {
-        "@sanity/block-tools": "3.0.0-dev-preview.20",
-        "@sanity/schema": "3.0.0-dev-preview.20",
+        "@sanity/block-tools": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/schema": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.0.0-dev-preview.20",
-        "@sanity/util": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/ui": "0.38.3-next.30",
+        "@sanity/util": "3.0.0-purple-unicorn.6+ef1e764093",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -10952,12 +11257,22 @@
       },
       "dependencies": {
         "@sanity/types": {
-          "version": "3.0.0-dev-preview.20",
-          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-          "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+          "version": "3.0.0-purple-unicorn.6",
+          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+          "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
           "requires": {
             "@sanity/client": "^3.4.1",
-            "@types/react": "^17.0.42"
+            "@types/react": "^18.0.21"
+          }
+        },
+        "@types/react": {
+          "version": "18.0.21",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+          "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
         },
         "debug": {
@@ -10971,12 +11286,12 @@
       }
     },
     "@sanity/schema": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-GD4MKMgKHL8JL4DKFbyVAK4SQkXNvY8kyMr18UBOxL9mA6/vhXeS7H0V5rGNge7wSgf1SFcYsLExhnaNJWzAzw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-N4k14WEFImx7XPNAwFLCwUAudSw3m52C9p5MLO7KOOqnnXHgYCbYy2LI3TlLM1ftRa23SRgaL7GiKls2ngpOYQ==",
       "requires": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -10985,20 +11300,30 @@
       },
       "dependencies": {
         "@sanity/types": {
-          "version": "3.0.0-dev-preview.20",
-          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-          "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+          "version": "3.0.0-purple-unicorn.6",
+          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+          "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
           "requires": {
             "@sanity/client": "^3.4.1",
-            "@types/react": "^17.0.42"
+            "@types/react": "^18.0.21"
+          }
+        },
+        "@types/react": {
+          "version": "18.0.21",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+          "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
         }
       }
     },
     "@sanity/server": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-IAuGkYsCYFuYTuFcDWx+I3mGoEBbPBe+nU1uY7QOCJyHvpP5a4Fy8LtyT/Xp60/uYFUJEhKjo8yKG+/8WnV5Xg==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-J1R2raj+Aeyt1PAuoOhmxDPB8RWO7mlhvHnI4GVCByPagNF2BXzu5WVY9ZR2yjVVVB8pIwZFqTefasHMaMENmw==",
       "requires": {
         "@sanity/generate-help-url": "^3.0.0",
         "@vitejs/plugin-react": "^2.0.0",
@@ -11066,42 +11391,57 @@
         "@sanity/color": "^2.1.14",
         "@types/react": "^17.0.42",
         "rxjs": "^6.5.3"
+      },
+      "dependencies": {
+        "@sanity/color": {
+          "version": "2.1.16",
+          "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.16.tgz",
+          "integrity": "sha512-R5Wh4qt+Jv20nvwSwE5xA+eS3kF2diPA6noAPQZSUsSG9UIUGGgxJyU0hWUa9O06RTCNqgBQI1YJiZTeJ6S7SA=="
+        }
       }
     },
     "@sanity/ui": {
-      "version": "0.38.2",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.38.2.tgz",
-      "integrity": "sha512-jP0NoEmSIws97tkLifRHuzTKvEztXakcAGuJ6jJ45IYUjgQXZp3bpDobfD9TZY4eeR0WafUB3UntkfSHqRVNOQ==",
+      "version": "0.38.3-next.30",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.38.3-next.30.tgz",
+      "integrity": "sha512-hilbAt6j6yE0t+fkEu9eVwiZTr6ZPtQI59TCa4YnhtlmHLnwlDHbwUhr5+Xy5Qo3KNRXsuPwbFfsHxAbVlKLTQ==",
       "requires": {
-        "@juggle/resize-observer": "^3.4.0",
         "@popperjs/core": "^2.11.6",
-        "@reach/auto-id": "^0.17.0",
-        "@sanity/color": "^2.1.16",
-        "@sanity/icons": "^1.3.6",
-        "framer-motion": "6.3.0",
+        "@sanity/color": "2.1.17-next.30+8cd982e0",
+        "@sanity/icons": "1.3.7-next.30+8cd982e0",
+        "framer-motion": "^7.5.2",
         "popper-max-size-modifier": "^0.2.0",
-        "react-is": "^17.0.2",
+        "react-is": "^18.2.0",
         "react-popper": "^2.3.0",
         "react-refractor": "^2.1.7"
       }
     },
     "@sanity/util": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-NLwe3oDMkS42+LJksu7qTOQP6R86oYcyy6Mxn7FF34yMy5y5YDc4c9kFkf3p/F1boOoiyA5vr5XWaudGpqZ/Kg==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-xr6+Sv1JTtGjnBGDTHShi3TS8dnm52NHB/AoNbCzSxNwGw4Y4nL8c/BF0+RWin6QVzFG239sG3RpcuaZnmJWQQ==",
       "requires": {
-        "@sanity/types": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
       "dependencies": {
         "@sanity/types": {
-          "version": "3.0.0-dev-preview.20",
-          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-          "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+          "version": "3.0.0-purple-unicorn.6",
+          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+          "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
           "requires": {
             "@sanity/client": "^3.4.1",
-            "@types/react": "^17.0.42"
+            "@types/react": "^18.0.21"
+          }
+        },
+        "@types/react": {
+          "version": "18.0.21",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+          "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
         }
       }
@@ -11116,30 +11456,41 @@
       }
     },
     "@sanity/validation": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-i3BmytuikNR6e3tzPRq/AGYCgHSJAVsCQaCJmyU9vgBsYVBi5UrS0O2HPZZJEEcJK0E951F+YWSIIS/FCuFZpw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-Ypk/sm7IM+Cr3f4mMelHwUF/k2i2zkMLBPGdv7gaHVFYxfMD1zuMGBq8u+vCn5jRO6CErHsy9DFXSmlexbBaRg==",
       "requires": {
-        "@sanity/types": "3.0.0-dev-preview.20",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
         "date-fns": "^2.26.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "rxjs": "^6.5.3"
       },
       "dependencies": {
         "@sanity/types": {
-          "version": "3.0.0-dev-preview.20",
-          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-          "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+          "version": "3.0.0-purple-unicorn.6",
+          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+          "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
           "requires": {
             "@sanity/client": "^3.4.1",
-            "@types/react": "^17.0.42"
+            "@types/react": "^18.0.21"
+          }
+        },
+        "@types/react": {
+          "version": "18.0.21",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+          "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
         }
       }
     },
     "@sanity/vision": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-FTW7TJHbLTFYvASgGixbcnT2yec0cmKXOYHXEOJrICTTKRe3t9sF7gtvD8HUPfcQKJKl3JpxzNBkKiRUpgE5Yw==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-xnsX9LYS3evII5fOkpraew/7wAixJlxAwUoH84fHNHXq59BUuCC2plxI+Lb//vmosv8ZkVSrpRDcLeKZk+3RPA==",
       "requires": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -11150,9 +11501,9 @@
         "@juggle/resize-observer": "^3.3.1",
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
-        "@sanity/color": "^2.1.16",
-        "@sanity/icons": "^1.3.6",
-        "@sanity/ui": "^0.38.2",
+        "@sanity/color": "2.1.17-next.30",
+        "@sanity/icons": "1.3.7-next.30",
+        "@sanity/ui": "0.38.3-next.30",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -11291,11 +11642,6 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-    },
-    "@types/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
     },
     "@typescript-eslint/parser": {
       "version": "5.40.0",
@@ -13175,24 +13521,25 @@
       "dev": true
     },
     "framer-motion": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.0.tgz",
-      "integrity": "sha512-Nm6l2cemuFeSC1fmq9R32sCQs1eplOuZ3r14/PxRDewpE3NUr+ul5ulGRRzk8K0Aa5p76Tedi3sfCUaTPa5fRg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.5.3.tgz",
+      "integrity": "sha512-VvANga9Z7bYtKMAsM/je81FwJDHfThOYywN04xVQ4OGdMVY09Bowx/q7nZd6XtytLuv6byc6GT1mYwag+SQ/nw==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
-        "framesync": "6.0.1",
+        "@motionone/dom": "10.13.1",
+        "framesync": "6.1.2",
         "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "popmotion": "11.0.5",
+        "style-value-types": "5.1.2",
+        "tslib": "2.4.0"
       }
     },
     "framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "from2": {
@@ -14030,9 +14377,9 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-reduce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-reduce/-/json-reduce-2.0.0.tgz",
-      "integrity": "sha512-qHVKlo1O0gbDw9rBUGVOKocopfdDTwVjeAyuO8Oatg58sTD8rqM4Hp6MyYZIsta36QXHjL4sagT8/Nn52cHs8Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-reduce/-/json-reduce-3.0.0.tgz",
+      "integrity": "sha512-zvnhEvwhqTOxBIcXnxvHvhqtubdwFRp+FascmCaL56BT9jdttRU8IFc+Ilh2HPJ0AtioF8mFPxmReuJKLW0Iyw=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -14818,14 +15165,14 @@
       "integrity": "sha512-lzeppMFfxFJwAsMl/R+k1wbZqc4gBLp3qpIOEsmvqSfILUcWcM3XNP66a+1NCKfbGhBqGgXqnV5xGVB0GnKPVQ=="
     },
     "popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.5.tgz",
+      "integrity": "sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA==",
       "requires": {
-        "framesync": "6.0.1",
+        "framesync": "6.1.2",
         "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "style-value-types": "5.1.2",
+        "tslib": "2.4.0"
       }
     },
     "popper-max-size-modifier": {
@@ -15057,12 +15404,11 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-clientside-effect": {
@@ -15083,13 +15429,12 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-fast-compare": {
@@ -15126,9 +15471,9 @@
       }
     },
     "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -15177,16 +15522,6 @@
       "requires": {
         "observable-callback": "^1.0.2",
         "use-sync-external-store": "^1.2.0"
-      }
-    },
-    "react-sortable-hoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
-      "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
       }
     },
     "react-split-pane": {
@@ -15478,41 +15813,41 @@
       "integrity": "sha512-effkSW9cap879l6CVNdwL5iubVz8tkspqgfiqwgBgFQspV7152WHaLzr5590yR8oFgt7E1d4lO09uUhtAgUPoA=="
     },
     "sanity": {
-      "version": "3.0.0-dev-preview.20",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0-dev-preview.20.tgz",
-      "integrity": "sha512-wcVer7UbXfE9C0nJqppX22CMcNdoyZeoUDQ29JarHz6y2cvpiOCe+JNPchtGpQRkAgbCgkeNce/d7QgxGActPA==",
+      "version": "3.0.0-purple-unicorn.6",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0-purple-unicorn.6.tgz",
+      "integrity": "sha512-j65GiTgRgwsYjPrejIHlcMzEPgkPqEfTJS7LfPaHj3aW6I1yfw1WWONL3tbAtoUUPzjkxtzFlnu5weWAtijWhA==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
         "@portabletext/react": "^1.0.6",
         "@portabletext/types": "^1.0.3",
-        "@reach/auto-id": "^0.13.2",
         "@rexxars/react-json-inspector": "^8.0.1",
+        "@rexxars/react-sortable-hoc": "^2.0.0",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.0",
-        "@sanity/block-tools": "3.0.0-dev-preview.20",
-        "@sanity/cli": "3.0.0-dev-preview.20",
+        "@sanity/block-tools": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/cli": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/client": "^3.4.1",
-        "@sanity/color": "^2.1.16",
-        "@sanity/diff": "3.0.0-dev-preview.20",
+        "@sanity/color": "2.1.17-next.30",
+        "@sanity/diff": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/eventsource": "^3.0.1",
-        "@sanity/export": "3.0.0-dev-preview.20",
+        "@sanity/export": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "^1.3.6",
+        "@sanity/icons": "1.3.7-next.30",
         "@sanity/image-url": "^1.0.1",
-        "@sanity/import": "3.0.0-dev-preview.20",
-        "@sanity/logos": "1.1.15",
-        "@sanity/mutator": "3.0.0-dev-preview.20",
-        "@sanity/portable-text-editor": "3.0.0-dev-preview.20",
-        "@sanity/schema": "3.0.0-dev-preview.20",
-        "@sanity/server": "3.0.0-dev-preview.20",
-        "@sanity/types": "3.0.0-dev-preview.20",
-        "@sanity/ui": "^0.38.2",
-        "@sanity/util": "3.0.0-dev-preview.20",
+        "@sanity/import": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/logos": "1.1.18-next.30",
+        "@sanity/mutator": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/portable-text-editor": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/schema": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/server": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/types": "3.0.0-purple-unicorn.6+ef1e764093",
+        "@sanity/ui": "0.38.3-next.30",
+        "@sanity/util": "3.0.0-purple-unicorn.6+ef1e764093",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.0.0-dev-preview.20",
+        "@sanity/validation": "3.0.0-purple-unicorn.6+ef1e764093",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
-        "@types/react-is": "^17.0.1",
+        "@types/react-is": "^17.0.3",
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
         "chalk": "^4.1.2",
@@ -15539,7 +15874,7 @@
         "jsdom": "^20.0.0",
         "jsdom-global": "^3.0.2",
         "json-lexer": "^1.2.0",
-        "json-reduce": "^2.0.0",
+        "json-reduce": "^3.0.0",
         "json5": "^1.0.1",
         "lodash": "^4.17.21",
         "log-symbols": "^2.2.0",
@@ -15556,18 +15891,17 @@
         "react-copy-to-clipboard": "^5.0.4",
         "react-fast-compare": "^3.2.0",
         "react-focus-lock": "^2.8.1",
-        "react-is": "^17.0.2",
+        "react-is": "^18.2.0",
         "react-props-stream": "^1.0.0",
         "react-refractor": "^2.1.6",
         "react-rx": "^2.0.4",
-        "react-sortable-hoc": "^2.0.0",
         "read-pkg-up": "^7.0.1",
         "refractor": "^3.6.0",
         "resolve-from": "^5.0.0",
         "rimraf": "^3.0.2",
         "rxjs": "^6.5.3",
         "rxjs-etc": "^10.6.0",
-        "rxjs-exhaustmap-with-trailing": "^1.0.0",
+        "rxjs-exhaustmap-with-trailing": "^1.2.0",
         "sanity-diff-patch": "^1.0.9",
         "scroll-into-view-if-needed": "^2.2.29",
         "semver": "^7.3.5",
@@ -15579,23 +15913,17 @@
         "yargs": "^17.3.0"
       },
       "dependencies": {
-        "@reach/auto-id": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.13.2.tgz",
-          "integrity": "sha512-dWeXt6xxjN+NPRoZFXgmNkF89t8MEPsWLYjIIDf3gNXA/Dxaoytc9YBOIfVGpDSpdOwxPpxOu8rH+4Y3Jk2gHA==",
+        "@motionone/dom": {
+          "version": "10.12.0",
+          "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+          "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
           "requires": {
-            "@reach/utils": "0.13.2",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
-          "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
-          "requires": {
-            "@types/warning": "^3.0.0",
-            "tslib": "^2.1.0",
-            "warning": "^4.0.3"
+            "@motionone/animation": "^10.12.0",
+            "@motionone/generators": "^10.12.0",
+            "@motionone/types": "^10.12.0",
+            "@motionone/utils": "^10.12.0",
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.3.1"
           }
         },
         "@sanity/eventsource": {
@@ -15608,12 +15936,22 @@
           }
         },
         "@sanity/types": {
-          "version": "3.0.0-dev-preview.20",
-          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-dev-preview.20.tgz",
-          "integrity": "sha512-cyc4S32hoYTnTQ0Ao78bKObsEEosBQwzRzR/L3WYCvi/ALQpvOwr9CTehkHdipHAGUVg4SScGGll52TTxt6b9A==",
+          "version": "3.0.0-purple-unicorn.6",
+          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-purple-unicorn.6.tgz",
+          "integrity": "sha512-W8jboNtnC5YmwUYVdBJwlS21MLOY0bCjQvxlwadZhO4N38qokYP6OQ6r0L0j70fxwEy6wLH0uKbifbtzVysMAA==",
           "requires": {
             "@sanity/client": "^3.4.1",
-            "@types/react": "^17.0.42"
+            "@types/react": "^18.0.21"
+          }
+        },
+        "@types/react": {
+          "version": "18.0.21",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+          "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
         },
         "debug": {
@@ -15636,6 +15974,28 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
           "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA=="
+        },
+        "framer-motion": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+          "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+          "requires": {
+            "@emotion/is-prop-valid": "^0.8.2",
+            "@motionone/dom": "10.12.0",
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "popmotion": "11.0.3",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "framesync": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
         },
         "get-it": {
           "version": "5.2.1",
@@ -15697,10 +16057,30 @@
           "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-2.0.1.tgz",
           "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA=="
         },
+        "popmotion": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+          "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+          "requires": {
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
+        "style-value-types": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+          "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+          "requires": {
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.1.0"
+          }
         }
       }
     },
@@ -15713,17 +16093,16 @@
       }
     },
     "sanity-plugin-asset-source-unsplash": {
-      "version": "3.0.0-v3-studio.5",
-      "resolved": "https://registry.npmjs.org/sanity-plugin-asset-source-unsplash/-/sanity-plugin-asset-source-unsplash-3.0.0-v3-studio.5.tgz",
-      "integrity": "sha512-cC+xskZQ/CvLTf6tiI8i3OIh9jpbIPZ731i8WlyHCrv6CQHWISFlmajk6RwAL9gqLbhjCbM4DWzzdjNHfrNzEg==",
+      "version": "3.0.0-v3-studio.7",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-asset-source-unsplash/-/sanity-plugin-asset-source-unsplash-3.0.0-v3-studio.7.tgz",
+      "integrity": "sha512-OpDmmy+kXjWs0VJFlce7uQFj0VDGWdvUAbhHsYLlarEw5gC3lfZePmDHx4Ii3PnCG7VDne29FDPAJ8nzjAdAXA==",
       "requires": {
-        "@sanity/incompatible-plugin": "^1.0.0",
-        "@sanity/ui": "^0.38.0",
-        "lodash": ">=4.17.4",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "0.38.3-next.30",
+        "lodash": "^4.17.21",
         "react-infinite-scroll-component": "^6.1.0",
-        "react-photo-album": "^1.13.2",
-        "rxjs": ">=6.5.2",
-        "styled-components": "^5.2.0"
+        "react-photo-album": "^1.16.1",
+        "rxjs": "^6.5.2"
       }
     },
     "saxes": {
@@ -15735,12 +16114,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "scroll-into-view-if-needed": {
@@ -16050,12 +16428,12 @@
       "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
     },
     "style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.1.2.tgz",
+      "integrity": "sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q==",
       "requires": {
         "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "styled-components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@portabletext/react": "^1.0.6",
         "@sanity/image-url": "^1.0.1",
-        "@sanity/vision": "3.0.0-purple-unicorn.6",
+        "@sanity/vision": "3.0.0-purple-unicorn-quickfix.6",
         "@sanity/webhook": "^2.0.0",
         "classnames": "^2.3.2",
         "date-fns": "^2.29.3",
@@ -717,6 +717,31 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
+      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+      "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1959,9 +1984,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.0.0-purple-unicorn.6",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-purple-unicorn.6.tgz",
-      "integrity": "sha512-xnsX9LYS3evII5fOkpraew/7wAixJlxAwUoH84fHNHXq59BUuCC2plxI+Lb//vmosv8ZkVSrpRDcLeKZk+3RPA==",
+      "version": "3.0.0-purple-unicorn-quickfix.6",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-purple-unicorn-quickfix.6.tgz",
+      "integrity": "sha512-9TCIXpXvR91OHj1GC1wZNF2pkdN8Oi8YHAjsKeYI6MSWngOR6uEtkBrX9QvLRF0H5EvYEuTD0q+muIZnwuZkrQ==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1972,9 +1997,9 @@
         "@juggle/resize-observer": "^3.3.1",
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
-        "@sanity/color": "2.1.17-next.30",
-        "@sanity/icons": "1.3.7-next.30",
-        "@sanity/ui": "0.38.3-next.30",
+        "@sanity/color": "2.1.19-beta.0",
+        "@sanity/icons": "1.3.9-beta.0",
+        "@sanity/ui": "1.0.0-beta.29",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -1986,6 +2011,37 @@
         "@sanity/client": "^3.4.1",
         "react": "^18",
         "rxjs": "^6.5.3",
+        "styled-components": "^5.2"
+      }
+    },
+    "node_modules/@sanity/vision/node_modules/@sanity/color": {
+      "version": "2.1.19-beta.0",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.19-beta.0.tgz",
+      "integrity": "sha512-jQh6cJ+4Py2Exj6z8EFtUMoRLRRmOl4pe6IN36EvIWgn4UU7QmgwzRaI65OQZHC+9tzBs0KczKm+T/qGPKFc/Q=="
+    },
+    "node_modules/@sanity/vision/node_modules/@sanity/icons": {
+      "version": "1.3.9-beta.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.9-beta.0.tgz",
+      "integrity": "sha512-NR1trixqkMEJ6HFmYRflOwtiL/YyS6if2B3kAfDtz9IhfB3u+we9EFOVsMOB0ofseUdT31eubXmvrODSQoHwiQ==",
+      "peerDependencies": {
+        "react": "^18"
+      }
+    },
+    "node_modules/@sanity/vision/node_modules/@sanity/ui": {
+      "version": "1.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.0.0-beta.29.tgz",
+      "integrity": "sha512-W2vdmVjwT0IzK2uWnSEVHjcQ5LB0fpW2B0jxspB27HNIjNAZJojXCXYILpXYMgOZM0vnliU65UemFLeBNwFpnA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^1.0.0",
+        "@sanity/color": "2.1.19-beta.0",
+        "@sanity/icons": "1.3.9-beta.0",
+        "framer-motion": "^7.5.3",
+        "react-refractor": "^2.1.7"
+      },
+      "peerDependencies": {
+        "react": "^18",
+        "react-dom": "^18",
+        "react-is": "^18",
         "styled-components": "^5.2"
       }
     },
@@ -10501,6 +10557,27 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
+      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "requires": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+      "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
@@ -11488,9 +11565,9 @@
       }
     },
     "@sanity/vision": {
-      "version": "3.0.0-purple-unicorn.6",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-purple-unicorn.6.tgz",
-      "integrity": "sha512-xnsX9LYS3evII5fOkpraew/7wAixJlxAwUoH84fHNHXq59BUuCC2plxI+Lb//vmosv8ZkVSrpRDcLeKZk+3RPA==",
+      "version": "3.0.0-purple-unicorn-quickfix.6",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.0.0-purple-unicorn-quickfix.6.tgz",
+      "integrity": "sha512-9TCIXpXvR91OHj1GC1wZNF2pkdN8Oi8YHAjsKeYI6MSWngOR6uEtkBrX9QvLRF0H5EvYEuTD0q+muIZnwuZkrQ==",
       "requires": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -11501,15 +11578,39 @@
         "@juggle/resize-observer": "^3.3.1",
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
-        "@sanity/color": "2.1.17-next.30",
-        "@sanity/icons": "1.3.7-next.30",
-        "@sanity/ui": "0.38.3-next.30",
+        "@sanity/color": "2.1.19-beta.0",
+        "@sanity/icons": "1.3.9-beta.0",
+        "@sanity/ui": "1.0.0-beta.29",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
         "json5": "^1.0.1",
         "lodash": "^4.17.21",
         "react-split-pane": "^0.1.84"
+      },
+      "dependencies": {
+        "@sanity/color": {
+          "version": "2.1.19-beta.0",
+          "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.19-beta.0.tgz",
+          "integrity": "sha512-jQh6cJ+4Py2Exj6z8EFtUMoRLRRmOl4pe6IN36EvIWgn4UU7QmgwzRaI65OQZHC+9tzBs0KczKm+T/qGPKFc/Q=="
+        },
+        "@sanity/icons": {
+          "version": "1.3.9-beta.0",
+          "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.9-beta.0.tgz",
+          "integrity": "sha512-NR1trixqkMEJ6HFmYRflOwtiL/YyS6if2B3kAfDtz9IhfB3u+we9EFOVsMOB0ofseUdT31eubXmvrODSQoHwiQ=="
+        },
+        "@sanity/ui": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.0.0-beta.29.tgz",
+          "integrity": "sha512-W2vdmVjwT0IzK2uWnSEVHjcQ5LB0fpW2B0jxspB27HNIjNAZJojXCXYILpXYMgOZM0vnliU65UemFLeBNwFpnA==",
+          "requires": {
+            "@floating-ui/react-dom": "^1.0.0",
+            "@sanity/color": "2.1.19-beta.0",
+            "@sanity/icons": "1.3.9-beta.0",
+            "framer-motion": "^7.5.3",
+            "react-refractor": "^2.1.7"
+          }
+        }
       }
     },
     "@sanity/webhook": {

--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
   "dependencies": {
     "@portabletext/react": "^1.0.6",
     "@sanity/image-url": "^1.0.1",
-    "@sanity/vision": "3.0.0-dev-preview.20",
+    "@sanity/vision": "3.0.0-purple-unicorn.6",
     "@sanity/webhook": "^2.0.0",
     "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
-    "next": "latest",
+    "next": "^12.3.1",
     "next-sanity": "^1.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-is": "^17.0.2",
-    "sanity": "3.0.0-dev-preview.20",
-    "sanity-plugin-asset-source-unsplash": "3.0.0-v3-studio.5"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-is": "^18.2.0",
+    "sanity": "3.0.0-purple-unicorn.6",
+    "sanity-plugin-asset-source-unsplash": "3.0.0-v3-studio.7",
+    "styled-components": "^5.3.6"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.12",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@portabletext/react": "^1.0.6",
     "@sanity/image-url": "^1.0.1",
-    "@sanity/vision": "3.0.0-purple-unicorn.6",
+    "@sanity/vision": "3.0.0-purple-unicorn-quickfix.6",
     "@sanity/webhook": "^2.0.0",
     "classnames": "^2.3.2",
     "date-fns": "^2.29.3",


### PR DESCRIPTION
Sets us up to use the latest working `dev-preview` on react 18 until an official `dev-preview` is released.